### PR TITLE
Fix module import error. Improve Lexp Show represenation. Misc formatting

### DIFF
--- a/PA1Helper.hs
+++ b/PA1Helper.hs
@@ -9,7 +9,7 @@ import Text.Parsec.Char
 
 -- Haskell representation of lambda expression
 -- In Lambda Lexp Lexp, the first Lexp should always be Atom String
-data Lexp = Atom String | Lambda Lexp Lexp | Apply Lexp  Lexp 
+data Lexp = Atom String | Lambda Lexp Lexp | Apply Lexp Lexp
 
 -- Make it possible to determine if two lambda expressions are structurally equal
 instance Eq Lexp  where
@@ -21,29 +21,27 @@ instance Eq Lexp  where
 -- Allow for Lexp datatype to be printed like the Oz representation of a lambda expression
 instance Show Lexp  where 
     show (Atom v) = v
-    show (Lambda exp1 exp2) = "\\" ++ (show exp1) ++ "." ++ (show exp2) 
-    show (Apply exp1 exp2) = "(" ++ (show exp1) ++ " " ++ (show exp2) ++ ")" 
+    show (Lambda exp1 exp2) = "\\" ++ show exp1 ++ "." ++ show exp2 
+    show (Apply exp1 exp2) = "(" ++ show exp1 ++ " " ++ show exp2 ++ ")" 
 
 
 -- Reserved keywords in Oz
 -- P. 841 Table C.8, "Concepts, Techniques, and Models of Computer Programming", 
 -- Van Roy, Haridi
-ozKeywords = ["andthen","at","attr","break"
-              ,"case","catch","choice","class"
-              ,"collect","cond","continue"
-              ,"declare","default","define"
-              ,"dis","div","do","else"
-              ,"elsecase","elseif","elseof"
-              ,"end","export","fail","false"
-              ,"feat","finally","for","from"
-              ,"fun","functor","if","import"
-              ,"in","lazy","local","lock"
-              ,"meth","mod","not","of","or"
-              ,"orelse","prepare","proc"
-              ,"prop","raise","require"
-              ,"return","self","skip","then"
-              ,"thread","true","try","unit"
-              ] 
+ozKeywords=["andthen" , "at"     , "attr"     , "break"   ,
+            "case"    , "catch"  , "choice"   , "class"   ,
+            "collect" , "cond"   , "continue" , "declare" ,
+            "default" , "define" , "dis"      , "div"     ,
+            "do"      , "else"   , "elsecase" , "elseif"  ,
+            "elseof"  , "end"    , "export"   , "fail"    ,
+            "false"   , "feat"   , "finally"  , "for"     ,
+            "from"    , "fun"    , "functor"  , "if"      ,
+            "import"  , "in"     , "lazy"     , "local"   ,
+            "lock"    , "meth"   , "mod"      , "not"     ,
+            "of"      , "or"     , "orelse"   , "prepare" ,
+            "proc"    , "prop"   , "raise"    , "require" ,
+            "return"  , "self"   , "skip"     , "then"    ,
+            "thread"  , "true"   , "try"      , "unit"    ]
 
 -- Sparse language definition to define a proper Oz identifier
 -- An atom is defined as follows:
@@ -78,8 +76,7 @@ lambargs = do
 
 lamb = do
   char '\\'
-  p <- lambargs
-  return p
+  lambargs
 
 appargs = do
     var1 <- start
@@ -87,24 +84,22 @@ appargs = do
     var2 <- start
     return (Apply var1 var2)
 
-app = do
-  p <- m_parens appargs 
-  return p
+app = m_parens appargs 
 
 start = atom <|> lamb <|> app
 
 -- Use previously defined parser to parse a given String
 parseLExpr :: String -> Either ParseError Lexp 
-parseLExpr input = parse start "" input
+parseLExpr = parse start ""
 
 -- Given a list of Strings, return a list containing only Lexp objects
 -- for strings that are valid lambda expressions
 parseLEList :: [String]->[Lexp]
 parseLEList [] = []
 parseLEList (x:xs) = let xs' = parseLEList xs 
-                              in case (parseLExpr x) of
+                              in case parseLExpr x of
                                    Left err -> xs' 
-                                   Right x' -> (x':xs') 
+                                   Right x' -> x':xs' 
 
 -- Pretty printer for outputting inputted lambda expressions along with
 -- their reduced expressions. Integer used to distiguish between test cases.

--- a/PA1Helper.hs
+++ b/PA1Helper.hs
@@ -111,8 +111,8 @@ parseLEList (x:xs) = let xs' = parseLEList xs
 outputPrinter :: Int -> [(Lexp,Lexp)] -> IO()
 outputPrinter _ [] = return ()
 outputPrinter n ((lexp,lexp'):lexps) = do
-    putStrLn ("Input " ++ (show n) ++ ": " ++ (show lexp))
-    putStrLn ("Result " ++ (show n) ++ ": " ++ (show lexp'))
+    putStrLn ("Input  " ++ show n ++ ": " ++ show lexp)
+    putStrLn ("Result " ++ show n ++ ": " ++ show lexp')
     outputPrinter (n+1) lexps
 
 -- Given a filename and function for reducing lambda expressions,

--- a/PA1HelperDebug.hs
+++ b/PA1HelperDebug.hs
@@ -9,7 +9,7 @@ import Text.Parsec.Char
 
 -- Haskell representation of lambda expression
 -- In Lambda Lexp Lexp, the first Lexp should always be Atom String
-data Lexp = Atom String | Lambda Lexp Lexp | Apply Lexp Lexp 
+data Lexp = Atom String | Lambda Lexp Lexp | Apply Lexp Lexp
 
 -- Make it possible to determine if two lambda expressions are structurally equal
 instance Eq Lexp  where
@@ -41,8 +41,7 @@ ozKeywords=["andthen" , "at"     , "attr"     , "break"   ,
             "of"      , "or"     , "orelse"   , "prepare" ,
             "proc"    , "prop"   , "raise"    , "require" ,
             "return"  , "self"   , "skip"     , "then"    ,
-            "thread"  , "true"   , "try"      , "unit"
-              ] 
+            "thread"  , "true"   , "try"      , "unit"    ]
 
 -- Sparse language definition to define a proper Oz identifier
 -- An atom is defined as follows:
@@ -77,8 +76,7 @@ lambargs = do
 
 lamb = do
   char '\\'
-  p <- lambargs
-  return p
+  lambargs
 
 appargs = do
     var1 <- start
@@ -86,24 +84,22 @@ appargs = do
     var2 <- start
     return (Apply var1 var2)
 
-app = do
-  p <- m_parens appargs 
-  return p
+app = m_parens appargs 
 
 start = atom <|> lamb <|> app
 
 -- Use previously defined parser to parse a given String
 parseLExpr :: String -> Either ParseError Lexp 
-parseLExpr input = parse start "" input
+parseLExpr = parse start ""
 
 -- Given a list of Strings, return a list containing only Lexp objects
 -- for strings that are valid lambda expressions
 parseLEList :: [String]->[Lexp]
 parseLEList [] = []
 parseLEList (x:xs) = let xs' = parseLEList xs 
-                              in case (parseLExpr x) of
+                              in case parseLExpr x of
                                    Left err -> xs' 
-                                   Right x' -> (x':xs') 
+                                   Right x' -> x':xs' 
 
 -- Pretty printer for outputting inputted lambda expressions along with
 -- their reduced expressions. Integer used to distiguish between test cases.

--- a/PA1HelperDebug.hs
+++ b/PA1HelperDebug.hs
@@ -110,8 +110,8 @@ parseLEList (x:xs) = let xs' = parseLEList xs
 outputPrinter :: Int -> [(Lexp,Lexp)] -> IO()
 outputPrinter _ [] = return ()
 outputPrinter n ((lexp,lexp'):lexps) = do
-    putStrLn ("Input " ++ (show n) ++ ": " ++ (show lexp))
-    putStrLn ("Result " ++ (show n) ++ ": " ++ (show lexp'))
+    putStrLn ("Input  " ++ show n ++ ": " ++ show lexp)
+    putStrLn ("Result " ++ show n ++ ": " ++ show lexp')
     outputPrinter (n+1) lexps
 
 -- Given a filename and function for reducing lambda expressions,

--- a/PA1HelperDebug.hs
+++ b/PA1HelperDebug.hs
@@ -9,7 +9,7 @@ import Text.Parsec.Char
 
 -- Haskell representation of lambda expression
 -- In Lambda Lexp Lexp, the first Lexp should always be Atom String
-data Lexp = Atom String | Lambda Lexp Lexp | Apply Lexp  Lexp 
+data Lexp = Atom String | Lambda Lexp Lexp | Apply Lexp Lexp 
 
 -- Make it possible to determine if two lambda expressions are structurally equal
 instance Eq Lexp  where
@@ -28,21 +28,20 @@ instance Show Lexp  where
 -- Reserved keywords in Oz
 -- P. 841 Table C.8, "Concepts, Techniques, and Models of Computer Programming", 
 -- Van Roy, Haridi
-ozKeywords = ["andthen","at","attr","break"
-              ,"case","catch","choice","class"
-              ,"collect","cond","continue"
-              ,"declare","default","define"
-              ,"dis","div","do","else"
-              ,"elsecase","elseif","elseof"
-              ,"end","export","fail","false"
-              ,"feat","finally","for","from"
-              ,"fun","functor","if","import"
-              ,"in","lazy","local","lock"
-              ,"meth","mod","not","of","or"
-              ,"orelse","prepare","proc"
-              ,"prop","raise","require"
-              ,"return","self","skip","then"
-              ,"thread","true","try","unit"
+ozKeywords=["andthen" , "at"     , "attr"     , "break"   ,
+            "case"    , "catch"  , "choice"   , "class"   ,
+            "collect" , "cond"   , "continue" , "declare" ,
+            "default" , "define" , "dis"      , "div"     ,
+            "do"      , "else"   , "elsecase" , "elseif"  ,
+            "elseof"  , "end"    , "export"   , "fail"    ,
+            "false"   , "feat"   , "finally"  , "for"     ,
+            "from"    , "fun"    , "functor"  , "if"      ,
+            "import"  , "in"     , "lazy"     , "local"   ,
+            "lock"    , "meth"   , "mod"      , "not"     ,
+            "of"      , "or"     , "orelse"   , "prepare" ,
+            "proc"    , "prop"   , "raise"    , "require" ,
+            "return"  , "self"   , "skip"     , "then"    ,
+            "thread"  , "true"   , "try"      , "unit"
               ] 
 
 -- Sparse language definition to define a proper Oz identifier


### PR DESCRIPTION
Fixed an error when importing this module (naming).
Fixed the string representation of Lexp to allow for easy copy pasting.
